### PR TITLE
Fix 2.10.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-    "com.casualmiracles" %% "treelog" % "1.2.3",
+    "com.casualmiracles" %% "treelog" % "1.2.2",
     "org.scalaz" %% "scalaz-core" % "7.0.6")
 ```
 


### PR DESCRIPTION
It seems 1.2.3 doesn't exist at https://oss.sonatype.org/content/repositories/releases/com/casualmiracles/treelog_2.10/
