### PR TITLE
Reproduce and fix bug wherein annotations are lost in a complex treelog

### DIFF
--- a/src/main/scala/treelog/LogTreeSyntax.scala
+++ b/src/main/scala/treelog/LogTreeSyntax.scala
@@ -35,10 +35,10 @@ trait LogTreeSyntax[Annotation] {
           Tree.node(UndescribedLogTreeLabel(leftLabel.success && rightLabel.success, leftLabel.annotations ++ rightLabel.annotations), leftChildren ++ rightChildren)
 
         case (Tree.Node(leftLabel: UndescribedLogTreeLabel[Annotation], leftChildren), rightNode @ Tree.Node(rightLabel, rightChildren)) ⇒
-          Tree.node(UndescribedLogTreeLabel(leftLabel.success && rightLabel.success), leftChildren :+ rightNode)
+          Tree.node(UndescribedLogTreeLabel(leftLabel.success && rightLabel.success, leftLabel.annotations), leftChildren :+ rightNode)
 
         case (leftNode @ Tree.Node(leftLabel, leftChildren), Tree.Node(rightLabel: UndescribedLogTreeLabel[Annotation], rightChildren)) ⇒
-          Tree.node(UndescribedLogTreeLabel(leftLabel.success && rightLabel.success), leftNode #:: rightChildren)
+          Tree.node(UndescribedLogTreeLabel(leftLabel.success && rightLabel.success, rightLabel.annotations), leftNode #:: rightChildren)
 
         case (leftNode: Tree[LogTreeLabel[Annotation]], rightNode: Tree[LogTreeLabel[Annotation]]) ⇒
           Tree.node(UndescribedLogTreeLabel(leftNode.rootLabel.success && rightNode.rootLabel.success), Stream(leftNode, rightNode))
@@ -496,7 +496,7 @@ trait LogTreeSyntax[Annotation] {
       }
 
     private def branchHoister(tree: LogTree, description: String): LogTree = tree match {
-      case Tree.Node(l: UndescribedLogTreeLabel[Annotation], children) ⇒ Tree.node(DescribedLogTreeLabel(description, allSuccessful(children)), children)
+      case Tree.Node(l: UndescribedLogTreeLabel[Annotation], children) ⇒ Tree.node(DescribedLogTreeLabel(description, allSuccessful(children), l.annotations), children)
       case Tree.Node(l: DescribedLogTreeLabel[Annotation], children) ⇒ Tree.node(DescribedLogTreeLabel(description, allSuccessful(List(tree))), Stream(tree))
     }
 

--- a/src/test/scala/treelog/LogTreeSyntaxSpec.scala
+++ b/src/test/scala/treelog/LogTreeSyntaxSpec.scala
@@ -305,9 +305,11 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
+        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
+        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
 
       {
@@ -331,9 +333,11 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
+        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
+        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
 
       {
@@ -357,9 +361,11 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
+        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
+        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
     }
   }

--- a/src/test/scala/treelog/LogTreeSyntaxSpec.scala
+++ b/src/test/scala/treelog/LogTreeSyntaxSpec.scala
@@ -305,11 +305,9 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
-        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
-        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
 
       {
@@ -333,11 +331,9 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
-        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
-        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
 
       {
@@ -361,11 +357,9 @@ class LogTreeSyntaxSpec extends Spec with MustMatchers {
         } yield 0
 
         val hoistedComputation = computation ~> "Hoisted"
-        val reallyQuiteHighUpComputation = hoistedComputation ~> "Nice view from up here"
 
         assert(computation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
         assert(hoistedComputation.allAnnotations == Set(1, 2, 3, 4, 5, 6))
-        assert(reallyQuiteHighUpComputation == Set(1, 2, 3, 4, 5, 6))
       }
     }
   }


### PR DESCRIPTION
First off, apologies for doing this directly on 'master' - I had pushed back up to GitHub before I realised I'd been working directly on 'master' and not on a feature branch.

The bug is exhibited for complex log trees, annotations made deep down are not being picked up by calls to 'allAnnotations' made via the 'AnnotationsSyntax' enrichment.

I've added two tests for the simple for-comprehension case and for branch hoisting - the latter fails.

The fix is to cover the tree node rewriting cases in the monoid used by writer part of Treelog, and to patch the undescribed node case for branch hoisting.