### PR TITLE
Introducing monad transformer `DescribedComputationT` 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,11 +36,15 @@ val websiteSettings = site.settings ++ ghpages.settings ++ Seq[Setting[_]](
   }
 )
 
+resolvers += Resolver.sonatypeRepo("releases")
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")
+
 val allDependencies = Seq(
-  "org.scalaz"    %% "scalaz-core"     % "7.3.0-M8",
-  "org.scalatest" %% "scalatest"       % "3.0.0"   % "test",
-  "io.argonaut"   %% "argonaut"        % "6.2-RC1" % "test",
-  "io.argonaut"   %% "argonaut-scalaz" % "6.2-RC1" % "test")
+  "org.scalaz"    %% "scalaz-core"               % "7.3.0-M8",
+  "org.scalaz"    %% "scalaz-scalacheck-binding" % "7.3.0-M8" % "test",
+  "org.scalatest" %% "scalatest"                 % "3.0.0"    % "test",
+  "io.argonaut"   %% "argonaut"                  % "6.2-RC1"  % "test",
+  "io.argonaut"   %% "argonaut-scalaz"           % "6.2-RC1"  % "test")
 
 /* see http://www.scala-sbt.org/using_sonatype.html and http://www.cakesolutions.net/teamblogs/2012/01/28/publishing-sbt-projects-to-nexus/
  * Instructions from sonatype: https://issues.sonatype.org/browse/OSSRH-2841?focusedCommentId=150049#comment-150049

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")
 val allDependencies = Seq(
   "org.scalaz"    %% "scalaz-core"               % "7.3.0-M8",
   "org.scalaz"    %% "scalaz-scalacheck-binding" % "7.3.0-M8" % "test",
+  "org.scalaz"    %% "scalaz-effect"             % "7.3.0-M8" % "test",
   "org.scalatest" %% "scalatest"                 % "3.0.0"    % "test",
   "io.argonaut"   %% "argonaut"                  % "6.2-RC1"  % "test",
   "io.argonaut"   %% "argonaut-scalaz"           % "6.2-RC1"  % "test")

--- a/src/main/scala/treelog/LogTreeSyntaxWithoutAnnotations.scala
+++ b/src/main/scala/treelog/LogTreeSyntaxWithoutAnnotations.scala
@@ -1,9 +1,132 @@
 package treelog
 
-import scalaz.Show
+import scala.language.higherKinds
+import scalaz.Scalaz._
+import scalaz.{-\/, Functor, Monad, Show, \/-, _}
 
 object LogTreeSyntaxWithoutAnnotations extends LogTreeSyntax[Nothing] {
+
   implicit object NothingShow extends Show[Nothing] {
     override def shows(n: Nothing): String = ""
   }
+
+  /**
+    * Represents a computation of type `F[DescribedCompution[A]]`.
+    *
+    * Example:
+    * {{{
+    * val x: Option[DescribedComputation[Int]] = Some(1 ~> "1")
+    * val y: Option[DescribedComputation[Int]] = Some(2 ~> "1")
+    * val z: Option[DescribedComputation[Int]] = (for {
+    *   one <- DescribedComputationT(x)
+    *   two <- DescribedComputationT(y)
+    *   res <- DescribedComputationT(Some((one + two) ~> ("1 + 2 =" + _))
+    * } yield res).run
+    * }}}
+    **/
+  case class DescribedComputationT[F[_], A](run: F[DescribedComputation[A]]) {
+    self =>
+
+    def map[B](f: A => B)(implicit F: Functor[F]): DescribedComputationT[F, B] = DescribedComputationT(F.map(self.run)(_ map f))
+
+    def mapT[G[_], B](f: F[DescribedComputation[A]] => G[DescribedComputation[B]]): DescribedComputationT[G, B] = DescribedComputationT(f(self.run))
+
+    def flatMap[B](f: A => DescribedComputationT[F, B])(implicit F: Monad[F]): DescribedComputationT[F, B]
+    = {
+
+      val v: F[DescribedComputation[B]] = F.bind(self.run) { dcA =>
+        // we can extract computation result from dcA because Writer contains "Id[?]".
+        dcA.run.value match {
+          case \/-(a) =>
+            // if dcA succeeded,
+            for {
+              dcB <- f(a).run // compute another described computation returning B
+            } yield {
+              // we can concatenate computation history like this.
+              for {
+                _ <- dcA // we can drop returned value because we just need to concatenate descriptions.
+                b <- dcB // extracting final result of type B
+              } yield b // final result of this described computation should be B
+            }
+          case -\/(_) =>
+            // if previous computation failed, we just return the history.
+            // but we need to convert type of return value into B.
+            run.map(_.rightMap(_.asInstanceOf[B]))
+        }
+      }
+      // need to wrap DescribedComputation finally
+      DescribedComputationT(v)
+    }
+  }
+
+  // instances for DescribedComputationT
+  private trait DescribedComputationTMonad[F[_]] extends Monad[DescribedComputationT[F, ?]] {
+    implicit def F: Monad[F]
+
+    override def bind[A, B](fa: DescribedComputationT[F, A])(f: (A) => DescribedComputationT[F, B]): DescribedComputationT[F, B]
+    = fa.flatMap(f)
+
+    override def point[A](a: => A): DescribedComputationT[F, A] = DescribedComputationT(F.pure(success(a)))
+  }
+
+  implicit def describedComputationTMonad[F[_]](implicit F0: Monad[F]): Monad[DescribedComputationT[F, ?]] = new DescribedComputationTMonad[F] {
+    implicit def F: Monad[F] = F0
+  }
+
+  private trait DescribedComputationTHoist extends Hoist[DescribedComputationT] {
+    override def hoist[M[_] : Monad, N[_]](f: M ~> N)
+    = λ[DescribedComputationT[M, ?] ~> DescribedComputationT[N, ?]](_ mapT f)
+
+    def liftM[G[_], A](a: G[A])(implicit G: Monad[G]): DescribedComputationT[G, A]
+    = DescribedComputationT(G.map[A, DescribedComputation[A]](a)((a: A) => success(a)))
+
+    implicit def apply[G[_] : Monad]: Monad[DescribedComputationT[G, ?]]
+    = describedComputationTMonad[G]
+  }
+
+  implicit val dcTrans: Hoist[DescribedComputationT] = new DescribedComputationTHoist {}
+
+  implicit def describedComputationTEqual[F[_] : Monad, A](implicit F0: Equal[F[DescribedComputation[A]]]): Equal[DescribedComputationT[F, A]] =
+    F0.contramap((_: DescribedComputationT[F, A]).run)
+
+
+  /**
+    * This is just a small helper methods to construct DescribedComputationT for contextual f values.
+    * Example:
+    * {{{
+    * import scalaz.effect.IO._
+    * import IO._
+    * for {
+    *   line1 <- readLn ~> ("read input1: " + _)
+    *   line2 <- readLn ~> ("read input2: " + _)
+    *   res   <- putStr(line1 + line2) ~> ("output input1+input2: " + _)
+    * } return res
+    * }}}
+    *
+    * If you want to handle error, you can have several ways.
+    * 1.  Id F is an instance of MonadError class, you can call recover error and call ~> like this
+    * {{{
+    * monadErrorValue.handleError( err => ..return normal computation..) ~> description
+    * }}}
+    *
+    * 2. Or, you can inspect value via match statement and construct described computation like this.
+    * {{{
+    * f match {
+    *   case v if v.isSuccess => DescribedComputationT(v.map(_.logSuccess(description))
+    *   case v if v.isFailure => DescribedComputationT(v.map(_.logFailure(description))
+    * }
+    * }}}
+    */
+  implicit class DescribedComputationTSyntax[F[_], A](fa: F[A]) {
+
+    def logSuccess(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = DescribedComputationT(fa.map(_.logSuccess(description)))
+    def ~>(description: String)(implicit F: Functor[F]): DescribedComputationT[F, A] = ~>(_ => description)
+    def ~>(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = logSuccess(description)
+
+    def logFailure(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = DescribedComputationT(fa.map(_.logFailure(description)))
+    def ~>!(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = logFailure(description)
+    def ~>!(description: String)(implicit F: Functor[F]): DescribedComputationT[F, A] = logFailure(_ => description)
+  }
+
+
 }

--- a/src/test/scala/DescribedComputationTExample.scala
+++ b/src/test/scala/DescribedComputationTExample.scala
@@ -1,0 +1,69 @@
+import treelog.LogTreeSyntaxWithoutAnnotations._
+
+import scalaz._
+import Scalaz._
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+object DescribedComputationTExample extends App {
+
+  // with Option
+  val optionExample = for {
+    one <- Option(1) ~> "1"
+    two <- Option(2) ~> "2"
+    res <- Option(one + two) ~> ("1 + 2: " + _)
+  } yield res
+  println(optionExample.run.get.run.written.show)
+
+
+  // with List
+  val listExample = for {
+    v1 <- List(1,2,3,4) ~> ("v1: " + _)
+    v2 <- List(10,20) ~> ("v2: " + _)
+    v3 <- List(v1 + v2) ~> ("v1+v2: " + _)
+  } yield v3
+  println(listExample.run.map(_.run.written.show).mkString(",\n"))
+
+
+  // with Tree
+  val tree1 = 1.node(2.leaf, 3.leaf)
+  val tree2 = 10.leaf
+  val treeExample = for {
+    v1 <- tree1 ~> ("value on tree1: " + _)
+    v2 <- tree2 ~> ("value on tree2: " + _)
+    v3 <- (v1 + v2).leaf ~> ("sum: " + _)
+  } yield v3
+  println(treeExample.run.map(_.run.written.show).drawTree)
+
+
+  // with Future
+  import scala.concurrent.ExecutionContext.Implicits.global
+  val f1 = Future(1)
+  val f2 = Future(2)
+  val futureExample = for {
+    v1 <- f1 ~> ("f1: " + _)
+    v2 <- f2 ~> ("f2: " + _)
+    v3 <- Future(v1 + v2) ~> ("f1 + f2: " + _)
+  } yield v3
+  println(Await.result(futureExample.run, Duration.Inf).run.written.show)
+
+
+  // with IO
+  import scalaz.effect.IO
+  import IO._
+  val dcT = for {
+    _    <- putStr("input some string> ") ~> "output prompt"
+    line <- readLn ~> ("input some string>: " + _)
+    res <- putStrLn(line) ~> ("putStrLn(line): " + _)
+  } yield {
+    res
+  }
+
+  // input some string from stdio
+  println("# Performing unsafePerformIO")
+  val dc =  dcT.run.unsafePerformIO
+
+  println("# Output described computation results")
+  println(dc.run.written.shows)
+
+}

--- a/src/test/scala/treelog/DescribedComputationTSpec.scala
+++ b/src/test/scala/treelog/DescribedComputationTSpec.scala
@@ -1,0 +1,57 @@
+package treelog
+
+import org.scalacheck.{Arbitrary, Properties}
+import treelog.LogTreeSyntaxWithoutAnnotations._
+
+import scala.language.higherKinds
+import scalaz.Scalaz._
+import scalaz._
+import scalaz.scalacheck.ScalazProperties._
+
+class DescribedComputationTSpec extends Properties("DescribedComputationTSpec") {
+
+  def checkAll(props: Properties) {
+    for ((name, prop) <- props.properties) yield {
+      property(name) = prop
+    }
+  }
+  def newProperties(name: String)(f: Properties => Unit): Properties = {
+    val p = new Properties(name)
+    f(p)
+    p
+  }
+
+  // checking laws
+  import scalaz.scalacheck.ScalazArbitrary._
+
+  // required arbitraries
+  implicit def describedComputationTArbitrary[F[_]: Monad, A](implicit a: Arbitrary[F[A]]):Arbitrary[DescribedComputationT[F, A]]
+  = Arbitrary( for( r <- a.arbitrary ) yield r ~> "test description" )
+
+
+  // Do we need more combinations ??
+  checkAll(newProperties("DescribedComputationT[Option,?]") { p =>
+    p.include(functor.laws[DescribedComputationT[Option,?]])
+    p.include(monad.laws[DescribedComputationT[Option,?]])
+    p.include(monadTrans.laws[DescribedComputationT, Option])
+  })
+
+  checkAll(newProperties("DescribedComputationT[Maybe,?]") { p =>
+    p.include(functor.laws[DescribedComputationT[Maybe,?]])
+    p.include(monad.laws[DescribedComputationT[Maybe,?]])
+    p.include(monadTrans.laws[DescribedComputationT, Maybe])
+  })
+
+  checkAll(newProperties("DescribedComputationT[List,?]") { p =>
+    p.include(functor.laws[DescribedComputationT[List,?]])
+    p.include(monad.laws[DescribedComputationT[List,?]])
+    p.include(monadTrans.laws[DescribedComputationT, List])
+  })
+
+  checkAll(newProperties("DescribedComputationT[Tree,?]") { p =>
+    p.include(functor.laws[DescribedComputationT[Tree,?]])
+    p.include(monad.laws[DescribedComputationT[Tree,?]])
+    p.include(monadTrans.laws[DescribedComputationT, Tree])
+  })
+
+}


### PR DESCRIPTION
This fixes #13 

Introducing `DescribedComputationT` enables users to handle _contextual_ values modeled by monads, e.g. (`scala.Option`, `scala.List`, `scalaz.Tree`, `scala.concurrent.Future`, `scalaz.effect.IO` etc.).

see [DescribedComputationTExample.scala](https://github.com/everpeace/treelog/blob/feature/DescribedComputationT/src/test/scala/DescribedComputationTExample.scala) for example.

I'm looking forward to having feedbacks.