### PR TITLE
Add `success` method

### DIFF
--- a/src/main/scala/treelog/LogTreeSyntaxWithoutAnnotations.scala
+++ b/src/main/scala/treelog/LogTreeSyntaxWithoutAnnotations.scala
@@ -6,6 +6,8 @@ import scalaz.{-\/, Functor, Monad, Show, \/-, _}
 
 object LogTreeSyntaxWithoutAnnotations extends LogTreeSyntax[Nothing] {
 
+  self: LogTreeSyntax[Nothing] =>
+  
   implicit object NothingShow extends Show[Nothing] {
     override def shows(n: Nothing): String = ""
   }
@@ -119,6 +121,8 @@ object LogTreeSyntaxWithoutAnnotations extends LogTreeSyntax[Nothing] {
     */
   implicit class DescribedComputationTSyntax[F[_], A](fa: F[A]) {
 
+    def success()(implicit F: Functor[F]): DescribedComputationT[F, A] = DescribedComputationT(fa.map(self.success(_)))
+    
     def logSuccess(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = DescribedComputationT(fa.map(_.logSuccess(description)))
     def ~>(description: String)(implicit F: Functor[F]): DescribedComputationT[F, A] = ~>(_ => description)
     def ~>(description: A => String)(implicit F: Functor[F]): DescribedComputationT[F, A] = logSuccess(description)


### PR DESCRIPTION
Proposing to add `success` method which lifts into a `DescribedComputationT` without description. Since such method is available out-of-the-box in `DescribedComputation`, why not add an equivalent monad transformer; I would find it useful personally.