### PR TITLE
Setup crossbuilding to scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
  language: scala
  scala:
-   - "2.12.6"
+   - "2.11.12"
+   - "2.12.8"
  jdk:
    - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 val buildSettings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq[Setting[_]](
   organization := "com.casualmiracles",
   name := "treelog",
+  crossScalaVersions := List("2.11.12", "2.12.8"),
   scalaVersion := "2.12.8",
-  scalaBinaryVersion := "2.12",
   scalacOptions := Seq(
     "-language:_",
    // "-Xfatal-warnings",


### PR DESCRIPTION
I would like to use this library in a project that is still on 2.11

I don't know how you handle releases, but running `sbt +publish` should publish for both 2.11 and 2.12 with this sbt configuration (I verified that it works for publishLocal at least).