### PR TITLE
build: support for scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
  language: scala
  scala:
    - "2.12.8"
+   - "2.13.0-M5"
  jdk:
    - oraclejdk8
+   - oraclejdk11
 
  cache:
    directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,13 @@
 lazy val buildSettings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq[Setting[_]](
-  organization := "com.casualmiracles",
-  name := "treelog-cats",
-  scalaVersion := "2.12.8",
-  scalaBinaryVersion := "2.12",
-  scalacOptions := Seq(
-    "-language:_",
-   // "-Xfatal-warnings",
-    "-deprecation",
-    "-encoding", "UTF-8",
-    "-feature",
-    "-unchecked",
-    "-Xlint",
-    "-Yno-adapted-args",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
-    "-Xfuture",
-    "-Ywarn-unused-import",
-    "-Ypartial-unification")
+  organization       := "com.casualmiracles",
+  name               := "treelog-cats",
+  scalaVersion       := "2.12.8",
+  crossScalaVersions := Seq(scalaVersion.value, "2.13.0-M5"),
+  releaseCrossBuild  := true,
+  scalacOptions      := util.scalacOptions(scalaVersion.value),
+  Compile / unmanagedSourceDirectories += {
+    (Compile / sourceDirectory).value / (if(util.priorTo2_13(scalaVersion.value)) "scala-2.12" else "scala-2.13")
+  }
 )
 
 enablePlugins(GhpagesPlugin)
@@ -33,9 +23,9 @@ addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
 lazy val allDependencies = Seq(
   "org.typelevel" %% "cats-core"     % "1.6.0",
   "org.typelevel" %% "cats-free"     % "1.6.0",
-  "org.scalatest" %% "scalatest"     % "3.0.5" % "test",
-  "io.argonaut"   %% "argonaut"      % "6.2.2"   % "test",
-  "io.argonaut"   %% "argonaut-cats" % "6.2.2"   % "test")
+  "org.scalatest" %% "scalatest"     % "3.0.7" % "test",
+  "io.argonaut"   %% "argonaut"      % "6.2.3" % "test",
+  "io.argonaut"   %% "argonaut-cats" % "6.2.3" % "test")
 
 /* see http://www.scala-sbt.org/using_sonatype.html and http://www.cakesolutions.net/teamblogs/2012/01/28/publishing-sbt-projects-to-nexus/
  * Instructions from sonatype: https://issues.sonatype.org/browse/OSSRH-2841?focusedCommentId=150049#comment-150049

--- a/project/util.scala
+++ b/project/util.scala
@@ -1,0 +1,28 @@
+import sbt._
+
+object util {
+
+def scalacOptions(scalaVersion: String): Seq[String] = {
+
+  Seq(
+    "-language:_",
+    "-deprecation",
+    "-encoding", "UTF-8",
+    "-feature",
+    "-unchecked",
+    "-Xlint",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Xfuture",
+    "-Ywarn-unused:imports"
+  ) ++ (if (priorTo2_13(scalaVersion)) Seq("-Yno-adapted-args", "-Ypartial-unification") else Nil)
+}
+
+def priorTo2_13(scalaVersion: String): Boolean =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, minor)) if minor < 13 => true
+    case _                              => false
+  }
+
+}

--- a/src/main/scala-2.12/treelog/ScalaCompat.scala
+++ b/src/main/scala-2.12/treelog/ScalaCompat.scala
@@ -1,0 +1,20 @@
+package treelog
+
+private[treelog] object ScalaCompat {
+
+  type LazyList[+T] = Stream[T]
+
+  object LazyList {
+
+    val #::  = Stream.#::
+    val cons = Stream.cons
+
+    def empty[T]: LazyList[T]         = Stream.empty[T]
+    def apply[T](xs: T*): LazyList[T] = xs.toLazyList
+  }
+
+  implicit class IterableOps[T](private val iterable: Iterable[T]) extends AnyVal {
+    def toLazyList: LazyList[T] = iterable.to[LazyList]
+  }
+
+}

--- a/src/main/scala-2.13/treelog/ScalaCompat.scala
+++ b/src/main/scala-2.13/treelog/ScalaCompat.scala
@@ -1,0 +1,28 @@
+package treelog
+
+import cats.{Eval, Foldable, Now}
+import cats.kernel.Order
+import cats.kernel.instances.StaticMethods
+
+private[treelog] object ScalaCompat {
+
+  implicit def orderForLazyList[A: Order]: Order[LazyList[A]] = new Order[LazyList[A]] {
+    def compare(xs: LazyList[A], ys: LazyList[A]): Int =
+      if (xs eq ys) 0 else StaticMethods.iteratorCompare(xs.iterator, ys.iterator)
+  }
+
+  implicit val foldableForLazyList: Foldable[LazyList] = new Foldable[LazyList] {
+    def foldLeft[A, B](fa: LazyList[A], b: B)(f: (B, A) => B): B = fa.foldLeft(b)(f)
+    def foldRight[A, B](fa: LazyList[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+      Now(fa).flatMap(s => if (s.isEmpty) lb else f(s.head, Eval.defer(foldRight(s.tail, lb)(f))))
+  }
+
+  implicit class LazyListCompanionOps(private val lc: LazyList.type) {
+    def apply[T](xs: T*): LazyList[T] = xs.toLazyList
+  }
+
+  implicit class IterableOps[T](private val iterable: Iterable[T]) extends AnyVal {
+    def toLazyList: LazyList[T] = iterable.to(LazyList)
+  }
+
+}

--- a/src/test/scala/treelog/LogTreeSyntaxSpec.scala
+++ b/src/test/scala/treelog/LogTreeSyntaxSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.refspec.RefSpec
 import org.scalatest.MustMatchers
 import treelog.Tree.{Leaf, Node}
 import cats.implicits._
+import ScalaCompat._
 
 class LogTreeSyntaxSpec extends RefSpec with MustMatchers {
   import LogTreeSyntaxWithoutAnnotations._
@@ -368,8 +369,8 @@ class LogTreeSyntaxSpec extends RefSpec with MustMatchers {
   }
 
   private def node(description: String, success: Boolean, children: Tree[LogTreeLabel[Nothing]]*) =
-    Node(DescribedLogTreeLabel(description, success), children.toStream)
+    Node(DescribedLogTreeLabel(description, success), children.toLazyList)
 
   private def node(success: Boolean, children: Tree[LogTreeLabel[Nothing]]*) =
-    Node(UndescribedLogTreeLabel(success), children.toStream)
+    Node(UndescribedLogTreeLabel(success), children.toLazyList)
 }


### PR DESCRIPTION
 - add `ScalaCompat` shims to support both 2.12
   & 2.13 and adjust code accordingly.

 - add util object under project for helper code.

 - add openjdk11 and scala 2.13 to travis