### PR TITLE
bump deps to versions that support 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
  language: scala
  scala:
    - "2.12.8"
-   - "2.13.0-M5"
+   - "2.13.0"
  jdk:
    - oraclejdk8
    - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
  language: scala
+ dist: trusty
  scala:
    - "2.12.8"
    - "2.13.0"

--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,12 @@ lazy val websiteSettings = Seq[Setting[_]](
 )
 
 resolvers += Resolver.sonatypeRepo("releases")
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
 lazy val allDependencies = Seq(
-  "org.typelevel" %% "cats-core"     % "1.6.1",
-  "org.typelevel" %% "cats-free"     % "1.6.1",
-  "org.scalatest" %% "scalatest"     % "3.0.8" % "test",
+  "org.typelevel" %% "cats-core"     % "2.0.0-M4",
+  "org.typelevel" %% "cats-free"     % "2.0.0-M4",
+  "org.scalatest" %% "scalatest"     % "3.1.0-SNAP13" % "test",
   "io.argonaut"   %% "argonaut"      % "6.2.3" % "test",
   "io.argonaut"   %% "argonaut-cats" % "6.2.3" % "test")
 


### PR DESCRIPTION
bump following dependencies to versions that support scala 2.13
- kindprojector to 0.10.3
- cats to 2.0.0-M4
- scalatest to 3.1.0-SNAP3

make travis compile version 2.13.0